### PR TITLE
Feature/11 category seed recomended

### DIFF
--- a/MyBudget/MyBudget/Data/CategoryRepository.swift
+++ b/MyBudget/MyBudget/Data/CategoryRepository.swift
@@ -13,6 +13,7 @@ protocol CategoryRepository {
     func insertCategory(_ category: Category) async throws
     func deleteCategory(_ category: Category) async throws
     func updateCategory() async throws
+    func seedRecomendedCategory() async throws
 }
 
 final class CategoryRepositoryImplement: CategoryRepository {
@@ -41,6 +42,29 @@ final class CategoryRepositoryImplement: CategoryRepository {
             try await database.saveForUpdate()
         } catch {
             print(error.localizedDescription)
+        }
+    }
+    
+    func seedRecomendedCategory() async throws {
+        guard let url = Bundle.main.url(forResource: "RecomendedCategory", withExtension: "json") else {
+            throw NSError(domain: "Seeder", code: 404, userInfo: [NSLocalizedDescriptionKey: "JSON 파일을 찾을 수 없습니다."])
+        }
+
+        let data = try Data(contentsOf: url)
+        let parsed = try JSONDecoder().decode([TransactionTypeEntity].self, from: data)
+
+        for typeEntity in parsed {
+            guard let transactionType = TransactionType.fromKoreanName(typeEntity.transactionType) else { continue }
+
+            for categoryEntity in typeEntity.category {
+                let category = Category(name: categoryEntity.name, transactionType: transactionType)
+
+                let subCategories = categoryEntity.subCategory.map {
+                    SubCategory(name: $0.name, parentCategory: category)
+                }
+                category.subCategories.append(contentsOf: subCategories)
+                try await database.insert(category)
+            }
         }
     }
 }

--- a/MyBudget/MyBudget/Model/Category.swift
+++ b/MyBudget/MyBudget/Model/Category.swift
@@ -26,14 +26,18 @@ import SwiftData
 class Category {
     @Attribute(.unique) var id: UUID = UUID()
     var name: String
+    var transactionType: TransactionType
+    
     @Relationship(deleteRule: .cascade, inverse: \SubCategory.parentCategory) var subCategories: [SubCategory]
     @Relationship(deleteRule: .cascade, inverse: \Transaction.category) var transactions: [Transaction]
 
     init(name: String,
+         transactionType: TransactionType,
          subCategories: [SubCategory] = [],
          transactions: [Transaction] = []
     ) {
         self.name = name
+        self.transactionType = transactionType
         self.subCategories = subCategories
         self.transactions = transactions
     }

--- a/MyBudget/MyBudget/Model/SubCategory.swift
+++ b/MyBudget/MyBudget/Model/SubCategory.swift
@@ -24,7 +24,7 @@ import SwiftData
 class SubCategory {
     @Attribute(.unique) var id: UUID = UUID()
     var name: String
-    var parentCategory: Category
+    var parentCategory: Category?
     @Relationship(deleteRule: .cascade, inverse: \Transaction.subCategory) var transactions: [Transaction]
 
     init(name: String,

--- a/MyBudget/MyBudget/Model/Transaction.swift
+++ b/MyBudget/MyBudget/Model/Transaction.swift
@@ -61,4 +61,13 @@ enum TransactionType: Int, Codable {
     case income
     case fixedExpance
     case varibleExpance
+    
+    static func fromKoreanName(_ name: String) -> TransactionType? {
+        switch name {
+        case "수입": return .income
+        case "고정 지출": return .fixedExpance
+        case "변동 지출": return .varibleExpance
+        default: return nil
+        }
+    }
 }

--- a/MyBudget/MyBudget/Model/Transaction.swift
+++ b/MyBudget/MyBudget/Model/Transaction.swift
@@ -21,8 +21,8 @@ class Transaction {
     var type: TransactionType
     var amount: Double
     var date: Date
-    var category: Category
-    var subCategory: SubCategory
+    var category: Category?
+    var subCategory: SubCategory?
     var paymentMethod: PaymentMethodDetail
     var location: String?
     var memo: String?

--- a/MyBudget/MyBudget/ViewModel/CategoryViewModel.swift
+++ b/MyBudget/MyBudget/ViewModel/CategoryViewModel.swift
@@ -49,7 +49,7 @@ final class CategoryViewModel {
     }
     
     private func insert() async throws {
-        let category = Category(name: newCategoryName)
+        let category = Category(name: newCategoryName, transactionType: .fixedExpance)
         try await repository.insertCategory(category)
         newCategoryName = ""
         try await fetch()

--- a/MyBudget/MyBudgetTests/CategoryRepositoryTests.swift
+++ b/MyBudget/MyBudgetTests/CategoryRepositoryTests.swift
@@ -25,8 +25,8 @@ struct CategoryRepositoryTests {
     }
     
     @Test func testInsert() async throws {
-        let category1 = Category(name: "Category1")
-        let category2 = Category(name: "Category2")
+        let category1 = Category(name: "Category1", transactionType: .income)
+        let category2 = Category(name: "Category2", transactionType: .income)
         
         try await repository.insertCategory(category1)
         var categories = try await repository.fetchCategory()
@@ -37,7 +37,7 @@ struct CategoryRepositoryTests {
     }
     
     @Test func testDelete() async throws {
-        let category1 = Category(name: "Category3")
+        let category1 = Category(name: "Category3", transactionType: .income)
         try await repository.insertCategory(category1)
         var categories = try await repository.fetchCategory()
         #expect(categories.count == 1)
@@ -48,7 +48,7 @@ struct CategoryRepositoryTests {
     
     @Test func testUpdate() async throws {
         let categoryName = "Category4"
-        let category1 = Category(name: categoryName)
+        let category1 = Category(name: categoryName, transactionType: .income)
         try await repository.insertCategory(category1)
         let category = try await repository.fetchCategory().first!
         #expect(category.name == categoryName)
@@ -59,5 +59,24 @@ struct CategoryRepositoryTests {
         #expect(categories.first!.id == category1.id)
         #expect(categories.first!.name == category.name)
     }
+    
+    @Test func testSeedRecomendedCategory() async throws {
+        // 1. 사전 상태 확인 - 비어있어야 함
+        var categories = try await repository.fetchCategory()
+        #expect(categories.isEmpty)
 
+        // 2. 시드 함수 실행
+        try await repository.seedRecomendedCategory()
+
+        // 3. 시드 결과 확인
+        categories = try await repository.fetchCategory()
+        #expect(!categories.isEmpty)
+
+        // 4. 하위 카테고리 포함 확인
+        let firstCategory = categories.first!
+        #expect(!firstCategory.subCategories.isEmpty)
+
+        // 5. TransactionType이 올바르게 매핑되었는지 확인
+        #expect(firstCategory.transactionType == .fixedExpance || firstCategory.transactionType == .varibleExpance || firstCategory.transactionType == .income)
+    }
 }

--- a/MyBudget/MyBudgetTests/SubCategoryRepositoryTests.swift
+++ b/MyBudget/MyBudgetTests/SubCategoryRepositoryTests.swift
@@ -24,7 +24,7 @@ struct SubCategoryRepositoryTests {
     }
     
     @Test func testInsert() async throws {
-        let category = Category(name: "ParentCategory")
+        let category = Category(name: "ParentCategory", transactionType: .fixedExpance)
         let subCategory1 = SubCategory(name: "SubCategory1", parentCategory: category)
         let subCategory2 = SubCategory(name: "SubCategory2", parentCategory: category)
         
@@ -37,7 +37,7 @@ struct SubCategoryRepositoryTests {
     }
     
     @Test func testDelete() async throws {
-        let category = Category(name: "ParentCategory")
+        let category = Category(name: "ParentCategory", transactionType: .fixedExpance)
         let subCategory3 = SubCategory(name: "SubCategory3", parentCategory: category)
         try await repository.insertSubCategory(subCategory3)
         var subCategories = try await repository.fetchSubCategory()
@@ -48,8 +48,8 @@ struct SubCategoryRepositoryTests {
     }
     
     @Test func testUpdate() async throws {
-        let category1 = Category(name: "ParentCategory1")
-        let category2 = Category(name: "ParentCategory2")
+        let category1 = Category(name: "ParentCategory1", transactionType: .fixedExpance)
+        let category2 = Category(name: "ParentCategory2", transactionType: .fixedExpance)
         let subCategory = SubCategory(name: "Sub", parentCategory: category1)
         try await repository.insertSubCategory(subCategory)
         let category = try await repository.fetchSubCategory().first!

--- a/MyBudget/MyBudgetTests/TransactionRepositoryTests.swift
+++ b/MyBudget/MyBudgetTests/TransactionRepositoryTests.swift
@@ -28,7 +28,7 @@ struct TransactionRepositoryTests {
     }
     
     @Test func testInsert() async throws {
-        let category = Category(name: "ParentCategory")
+        let category = Category(name: "ParentCategory", transactionType: .fixedExpance)
         let subCategory = SubCategory(name: "SubCategory", parentCategory: category)
         let paymentMethodDetail = PaymentMethodDetail(type: .creditCard, name: "우리카드")
         let transaction = Transaction(
@@ -45,7 +45,7 @@ struct TransactionRepositoryTests {
     }
     
     @Test func testDelete() async throws {
-        let category = Category(name: "ParentCategory")
+        let category = Category(name: "ParentCategory", transactionType: .fixedExpance)
         let subCategory = SubCategory(name: "SubCategory", parentCategory: category)
         let paymentMethodDetail = PaymentMethodDetail(type: .creditCard, name: "우리카드")
         let transaction = Transaction(
@@ -65,7 +65,7 @@ struct TransactionRepositoryTests {
     }
     
     @Test func testUpdate() async throws {
-        let category = Category(name: "ParentCategory")
+        let category = Category(name: "ParentCategory", transactionType: .fixedExpance)
         let subCategory = SubCategory(name: "SubCategory", parentCategory: category)
         let paymentMethodDetail = PaymentMethodDetail(type: .creditCard, name: "우리카드")
         let transaction = Transaction(


### PR DESCRIPTION
### key changes

- Category 모델에 transactionType: TransactionType 필드 추가
→ 카테고리의 성격(수입, 고정 지출, 변동 지출)을 명시적으로 표현
- RecomendedCategorySeeder 클래스 추가
→ RecomendedCategory.json 파일을 파싱하여 Category와 SubCategory로 변환 및 저장
- TransactionType 확장
→ 한국어 "수입", "고정 지출" 등 문자열을 enum으로 매핑하는 헬퍼 메서드 추가
- CategoryRepository에 seedRecomendedCategory() 메서드 추가
→ JSON 기반 초기 카테고리 시딩 로직을 외부에서 쉽게 호출 가능
- 유닛 테스트 추가
→ 시딩 이후 카테고리와 하위 카테고리 저장 여부, transactionType 매핑 정상 여부 테스트
- [버그 수정] Transaction.subCategory가 non-optional일 때 cascade delete 시 충돌 발생
→ subCategory를 optional로 변경하여 삭제 시 안전하게 관계 해제 가능하게 수정

close #11 